### PR TITLE
Handle single page of issues

### DIFF
--- a/issue.py
+++ b/issue.py
@@ -31,8 +31,11 @@ def getGitHubIssues(auth, repo):
         else:
             print(str(response.status_code) + ": " + response.json()['message'])
 
-        matches = re.findall('<(.*?)>; rel="(.*?)"', response.headers['link'])
-        links = dict((rel, url) for url, rel in matches)
+        if 'link' in response.headers:
+            matches = re.findall('<(.*?)>; rel="(.*?)"', response.headers['link'])
+            links = dict((rel, url) for url, rel in matches)
+        else:
+            links = dict()
 
     return githubIssues
 


### PR DESCRIPTION
If the github repository only has a single page of issues, then there
will be no 'link' keys in the response headers.

This results issue #20
