### PR TITLE
improve formatting for metadata

### DIFF
--- a/issues.py
+++ b/issues.py
@@ -130,7 +130,7 @@ def handle_tracker_item(item, issue_title_prefix, statusprintprefix):
     item_details = item.find('field',attrs={'name':'details'}).string
     item_date = datetime.fromtimestamp(float(item.find('field',attrs={'name':'open_date'}).string))
     body = '\n\n'.join([
-        'Submitted by %s on %s' % (item_submitter, str(item_date)),
+        '*Originally submitted to the SourceForge repository on %s by %s*\n----' % (str(item_date), item_submitter),
         item_details,
     ])
     closed = item_id in closed_status_ids
@@ -183,7 +183,7 @@ def handle_tracker_item(item, issue_title_prefix, statusprintprefix):
     for followup in messages:
         commentdate = datetime.fromtimestamp(float(followup.find('field',attrs={'name':'adddate'}).string))
         comments.insert(0,'\n\n'.join([
-            'Submitted by %s on %s' % (followup.find('field',attrs={'name':'user_name'}).string,str(commentdate)),
+            '*Original comment by %s on %s*\n----' % (followup.find('field',attrs={'name':'user_name'}).string,str(commentdate)),
             cleanup_message_body(followup.find('field',attrs={'name':'body'}).string),
         ]))
 


### PR DESCRIPTION
As promised over a year ago(!) on
https://github.com/mwclient/mwclient/issues/1#issuecomment-13969876

This change formats the metadata strings as italics,
and separates them from the text with a horizontal rule.
The language was also slightly reworded for increased clarity.

The result is similar to this (manually formatted) example:
https://github.com/mwclient/mwclient/issues/3
