### PR TITLE
Add prefixes to sf2ghJSON.py.

### DIFF
--- a/issue.py
+++ b/issue.py
@@ -42,9 +42,9 @@ def getGitHubIssues(auth, repo):
     return githubIssues
 
 def updateIssue(githubIssue, sfTicket, auth, milestoneNumbers, userdict,
-        closedStatusNames, appendSFNumber, collaborators):
+        closedStatusNames, appendSFNumber, collaborators, prefix = ""):
     updateData = {
-        'title': githubIssue['title']
+        'title': prefix + ("" if prefix == "" else " ") + githubIssue['title']
     }
 
     if appendSFNumber:
@@ -71,7 +71,7 @@ def updateIssue(githubIssue, sfTicket, auth, milestoneNumbers, userdict,
     message = response.json().get('message')
     return (response.status_code, message)
 
-def updateAllIssues(auth, repo, json_data, appendSFNumber, collaborators):
+def updateAllIssues(auth, repo, json_data, appendSFNumber, collaborators, prefix = ""):
     print("Fetching milestones...")
     milestoneNumbers = milestones.getMilestoneNumbers(auth, repo)
     print("Milestones: " + str(len(milestoneNumbers)))
@@ -105,7 +105,7 @@ def updateAllIssues(auth, repo, json_data, appendSFNumber, collaborators):
             sfTicket = matchingTickets[0]
 
             (statusCode, message) = updateIssue(githubIssue, sfTicket, auth,
-                milestoneNumbers, userdict, closedStatusNames, appendSFNumber, collaborators)
+                milestoneNumbers, userdict, closedStatusNames, appendSFNumber, collaborators, prefix)
             if statusCode == requests.codes.ok:
                 successes += 1
             else:

--- a/sf2ghJSON.py
+++ b/sf2ghJSON.py
@@ -56,7 +56,22 @@ def getCollaborators(auth, repo):
     else:
         print(str(response.status_code) + ": " + response.json()['message'])
     return collaborators
-    
+
+def getPrefix(export):
+    prefixes = {
+        "Bugs": "[Bug]",
+        "Feature Request": "[Feature]",
+        "Feature Requests": "[Feature]",
+        "Patch": "[Patch]",
+        "Patches": "[Patch]",
+        "Support Requests": "[Support]",
+        "Tech Support": "[Support]"
+    }
+    trackerName = export["tracker_config"]["options"]["mount_label"]
+    if trackerName not in prefixes:
+        return ""
+    return prefixes[trackerName]
+
 def createGitHubArtifact(sfArtifacts, githubName, conversionFunction):
     print("-----------------")
     print(githubName.upper())
@@ -89,4 +104,5 @@ collaborators = getCollaborators(auth, args.repo)
 createGitHubArtifact(export['milestones'], "milestones", milestone.sf2github)
 tickets = sorted(export['tickets'], key=lambda t: t['ticket_num'])
 createGitHubArtifact(tickets, "issues", issue.sf2github)
-issue.updateAllIssues(auth, args.repo, export, not args.no_id_in_title, collaborators)
+prefix = getPrefix(export)
+issue.updateAllIssues(auth, args.repo, export, not args.no_id_in_title, collaborators, prefix)


### PR DESCRIPTION
Add the title prefixes based on tracker names also to the sf2ghJSON.py
script. If the tracker has a non-standard name, no prefix is added (same
behavior as before). If it has a standard name, the same prefixes as in
issues.py are used.
