### PR TITLE
add exception-handling for patches

### DIFF
--- a/issue.py
+++ b/issue.py
@@ -136,9 +136,19 @@ def addAllComments(auth, issueURL, sfPosts):
         
         for attach in sfPost['attachments']:
             print("   Adding attached file: " + attach['url'])
-            post += "\nAttached file" + attach['url'].split('/')[-1] + ":\n\n"
-            for line in urllib2.urlopen(attach['url']):
-                post += '    ' + line
+            post += "\nAttached file " + attach['url'].split('/')[-1] + ":\n\n"
+
+            try:
+                for line in urllib2.urlopen(attach['url']):
+                    post += '    ' + line
+            except urllib2.URLError as e:
+                print("   !!! Could not add attachement: " + e.reason)
+                post += "The file could not get attached: " + e.reason + "\n"
+                failures += 1
+            except urllib2.HTTPError as e:
+                print("   !!! Could not add attachement: " + e.reason)
+                post += "The file could not get attached: " + e.reason + "\n"
+                failures += 1
 
         (statusCode, message) = addComment(auth, issueURL, post)
         if statusCode == 201:


### PR DESCRIPTION
My PR #32 was not good enough. I stumbled over my own code.

The specific case, when the exceptions are needed: If you delete the module on sourceforge, the patches are also deleted, cause they are saved on SF's server and not included in the JSON-export.

If you export the JSON, delete the module on sourceforge and then start importing your tracker history, it still continues after this change to import your JSON-data without the patches.

Without the patches, it would just break and stop.