### PR TITLE
Add sf2gh, a wrapped virtual environment command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 *.json
+
+# sf2gh local virtual environment
+.sf2gh-virtualenv/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 sf2github README
 ================
 
-`sf2github` is a Python program
+sf2github is a Python program
 that reads a JSON export from a SourceForge project
 and pushes this data to GitHub via its REST API.
 
-The preferred entry point is the sf2ghJSON.py script.
+The preferred entry point is `sf2gh`.
 
 The script is currently somewhat incomplete and barely tested.
 If it works for you, great; if not, fix it up and send me a pull request!
@@ -61,19 +61,26 @@ http://help.github.com/svn-importing/
 Usage
 -----
 
-sf2github depends on the [BeautifulSoup](http://www.crummy.com/software/BeautifulSoup/),
-the [requests](http://docs.python-requests.org/en/latest/) and the 're' modules.
-If you don't have them, install them first.
-
 From SourceForge, you need to export the tracker data. This is done through
 the Export function of the admin interface.
 
-For more details on usage, run the `sf2ghJSON.py` script and it will print
+For more details on usage, run `sf2gh -h` and it will print
 further instructions.
 Basically, if your SF export is in `bugs.json`, your GitHub username is `john`
 and your repository is `bar`:
 
-    ./sf2ghJSON.py bugs.json john/bar
+    ./sf2gh bugs.json john/bar
+
+
+*Manual installation*
+
+The `sf2gh` command uses `python2.7` and wraps execution in a virtual
+environment installed using `virtualenv` and `pip`. If that doesn't work for
+you, try installing dependencies in `requirements.txt` and then running
+`./sf2ghJSON.py` directly.
+
+
+
 
 License
 -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+beautifulsoup4==4.3.2
+requests==2.6.0

--- a/sf2gh
+++ b/sf2gh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -e
+
+function req {
+	local program="$1"
+
+	if [[ -z "$(which "$program")" ]];
+	then
+		echo "$program is required" >&2
+		exit 1
+	fi
+}
+
+req python2.7
+req virtualenv
+req pip
+
+
+SF2GH_VENV="${BASH_SOURCE%/*}/.sf2gh-virtualenv"
+
+[[ -d "$SF2GH_VENV" ]] || NEEDS_INSTALLATION="true"
+
+if [[ "$NEEDS_INSTALLATION" == "true" ]];
+then
+	# Create new virtualenv directory.
+	virtualenv --python python2.7 --no-site-packages "${SF2GH_VENV}"
+
+	# Just an empty line to group output lines.
+	echo
+fi
+
+# Deactivate virtual environment before exiting script.
+trap deactivate EXIT;
+
+# Activate virtual environment.
+source "${SF2GH_VENV}/bin/activate"
+
+if [[ "$NEEDS_INSTALLATION" == "true" ]];
+then
+	# Install python packages/dependencies.
+	pip install --no-deps --requirement requirements.txt
+
+	# Just an empty line to group output lines.
+	echo
+fi
+
+python "${BASH_SOURCE%/*}/sf2ghJSON.py" "$@"


### PR DESCRIPTION
To make sure a specific version of python and dependencies are used, add
`requirements.txt` and a bash script `sf2gh` which ensures the virtual
environment is activated and dependencies installed.

Decided not to use sf2gh myself, for now, so this wrapper is not to be
considered well tested. Let me know if it works for you guys!